### PR TITLE
Introducing ranges splitting

### DIFF
--- a/inequalityengine.py
+++ b/inequalityengine.py
@@ -10,6 +10,8 @@ OP = {
         ' or ' : ['||', ' | ', ' or '],
         }
 VALID_OP = sum(OP.values(),[])
+STD_OP = list(OP.keys())
+RANGE_OP = [STD_OP[1], STD_OP[2], STD_OP[3], STD_OP[4]]
 
 def clear_double_spaces(input_string : str) -> str:
     input_string = input_string.strip().rstrip()
@@ -18,19 +20,38 @@ def clear_double_spaces(input_string : str) -> str:
     return input_string
 
 def translate(input_string : str) -> str:
-    for translated_op in OP.keys():
+    for translated_op in STD_OP:
         op_list = OP[translated_op]
         for op in op_list:
             input_string = input_string.replace(op, translated_op)
     return input_string
 
+def ingest(input_string : str) -> str:
+    return clear_double_spaces(translate(clear_double_spaces(input_string)))
+
+def convert_ranges(input_string : str) -> list:
+    numop = sum(input_string.count(op) for op in RANGE_OP)
+    if numop == 2:
+        l = input_string.split(' ')
+        l.insert(2, l[2])
+        return [' '.join(l[0:3]), ' '.join(l[3:])]
+    else:
+        return [input_string.strip(' ').rstrip(' ')]
+
 class inequality_engine:
     def __init__(self, input_string):
-        input_string = clear_double_spaces(translate(clear_double_spaces(input_string)))
+        input_string = ingest(input_string)
         or_groups = input_string.split(';')
         self.filters = []
         for og in or_groups:
-            self.filters.append(og.split(','))
+            conditions = og.split(',')
+            converted = []
+            for cond in conditions:
+                converted.extend(convert_ranges(cond))
+            self.filters.append(converted)
+        
+        if not self.filters or self.filters == [['']]:
+            raise ValueError("No filter defined. Aborting.")
 
     def run(self):
         return any(map(lambda and_group: all(map(lambda expr: eval(expr), and_group)), self.filters))

--- a/test_inequalityengine.py
+++ b/test_inequalityengine.py
@@ -62,6 +62,25 @@ class TestInequalityEngine(unittest.TestCase):
         string = "100 < 42; False; 7 > 8; 2**10 == 1024"
         self.assertTrue(inequality_engine(string).run())
 
+    def test_RangeConversion(self):
+        string = "2 < 10 < 100"
+        self.assertTrue(inequality_engine(string).run())
+
+        string = "20 > 10 < 100"
+        self.assertTrue(inequality_engine(string).run())
+
+        string = "2 < 100 <= 100"
+        self.assertTrue(inequality_engine(string).run())
+
+        string = "2 < 100 < 100"
+        self.assertFalse(inequality_engine(string).run())
+
+        string = "20 > 10 > 100"
+        self.assertFalse(inequality_engine(string).run())
+
+        string = "20 >= 20 >= 100"
+        self.assertFalse(inequality_engine(string).run())
+
     def test_InequalityEngine(self):
         string = "True, True; True"
         self.assertTrue(inequality_engine(string).run())


### PR DESCRIPTION
This is much needed to keep the queries simple.
A range condition `A < test < B` can be written as `A < test and test < B` and this update does exactly this.